### PR TITLE
ci: add pre-commit hooks configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       - id: check-case-conflict          # Case-insensitive filesystem issues
       - id: check-executables-have-shebangs  # Ensure executables have a valid shebang
 
-# For allowing secrets to be committed, add this comment: # gitleaks:allow
+  # For allowing secrets to be committed, add this comment: # gitleaks:allow
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.21.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,41 @@
+# Requirements:
+### MacOS: `brew install pre-commit`
+### Linux: `pip3 install pre-commit`
+
+# NOTE: The first run will take some time as it will download all the hooks.
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      # Prevent committing to main directly
+      - id: no-commit-to-branch
+        args: ['--branch', 'main']
+
+      # Catch merge conflict markers
+      - id: check-merge-conflict
+
+      # Validate file formats
+      - id: check-yaml
+        args: ['--allow-multiple-documents']
+      - id: check-json
+      - id: check-toml
+
+      # Detect private keys
+      - id: detect-private-key
+
+      # Clean up whitespace issues
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: ['--fix=lf']
+
+      # Detect filesystem and executable issues
+      - id: check-case-conflict          # Case-insensitive filesystem issues
+      - id: check-executables-have-shebangs  # Ensure executables have a valid shebang
+
+# For allowing secrets to be committed, add this comment: # gitleaks:allow
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
## Summary
- Add pre-commit hooks configuration for code quality checks

### Hooks included:
- Prevent committing to main directly
- Check for merge conflicts
- Validate YAML, JSON, and TOML files
- Detect private keys
- Fix trailing whitespace and end-of-file issues
- Normalize line endings to LF
- Check for case conflicts
- Ensure executables have shebangs
- Detect hardcoded secrets with gitleaks

## Requirements
- MacOS: `brew install pre-commit`
- Linux: `pip3 install pre-commit`